### PR TITLE
Add Accepted Papers page to CONCUR section

### DIFF
--- a/_data/submenu/concur.yml
+++ b/_data/submenu/concur.yml
@@ -5,5 +5,7 @@ submenu:
     relative_url: /concur/committees
   - name: Call for papers
     relative_url: /concur/call-for-papers
+  - name: Accepted Papers
+    relative_url: /concur/accepted-papers
   - name: Past Editions
     relative_url: /concur/past-editions

--- a/concur/accepted-papers.md
+++ b/concur/accepted-papers.md
@@ -1,0 +1,15 @@
+---
+title: Accepted Papers
+layout: default
+subnav: concur
+---
+
+# {{page.title}}
+
+<ul>
+    {% for paper in site.data.concur-accepted-papers %}
+        <li>
+            <strong>{{ paper.Authors }}</strong>. {{ paper.Title }}
+        </li>
+    {% endfor %}
+</ul>


### PR DESCRIPTION
This PR adds a new 'Accepted Papers' subpage to the CONCUR section.

**Changes:**
- Created `concur/accepted-papers.md` with Liquid templating to display papers from the CSV data
- Updated `_data/submenu/concur.yml` to add the page to the navigation menu
- The page uses a Liquid iterator to loop through `site.data.concur-accepted-papers` and displays authors and titles in a bullet list format

The implementation follows the existing Jekyll patterns used throughout the CONCUR section.